### PR TITLE
Add `fpermissive` flag to CMAKE_CXX_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ include(${VTK_USE_FILE})
 
 include_directories(SYSTEM ${OpenCL_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
-set(CMAKE_CXX_FLAGS "-Wall -O3 -std=c++11")
+set(CMAKE_CXX_FLAGS "-Wall -O3 -std=c++11 -fpermissive")
 
 add_subdirectory(src)
 add_subdirectory(test)


### PR DESCRIPTION
Ignoring errors about nonconformant code thus avoiding the build issue #2
