### PR TITLE
Explicitly define namespace of ifstream and ofstream

### DIFF
--- a/src/utilities/aslParametersManager.cxx
+++ b/src/utilities/aslParametersManager.cxx
@@ -332,7 +332,7 @@ namespace asl
 
 		try
 		{
-			ifstream ifs(paramFile);
+			std::ifstream ifs(paramFile);
 			if (!ifs.good())
 				errorMessage("Can not open parameters file: " + paramFile);
 
@@ -357,7 +357,7 @@ namespace asl
 
 	void ParametersManager::writeParametersFile(const std::string fileName)
 	{
-		ofstream fo(fileName);
+		std::ofstream fo(fileName);
 		if (!fo.good())
 			errorMessage("ParametersManager::writeParametersFile() - can not open file: " + fileName);
 
@@ -463,7 +463,7 @@ namespace asl
 				}
 				else
 				{
-					ifstream ifs(p.string());
+					std::ifstream ifs(p.string());
 					if (ifs.good())
 					{
 						parsed_options parsed = parse_config_file(ifs, allOptions, true);


### PR DESCRIPTION
With GCC 5.3.0 and Boost 1.60.0, the build fails with following error:
/build/libasl/src/ASL-0.1.6/src/utilities/aslParametersManager.cxx:466:6:
error: reference to 'ifstream' is ambiguous
      ifstream ifs(p.string());
      ^
/usr/include/boost/filesystem/fstream.hpp:169:32: note: candidates are:
typedef class boost::filesystem::basic_ifstream<char> boost::filesystem::ifstream
   typedef basic_ifstream<char> ifstream;
                                ^
