### PR TITLE
Bugfix: "ambiguous call to 'select'" caused by aslLevelSetLinear.cxx

### DIFF
--- a/src/num/aslLevelSetLinear.cxx
+++ b/src/num/aslLevelSetLinear.cxx
@@ -183,7 +183,8 @@ namespace asl
 		                     //DistFNormalization::scaleFactor);
 		kk << (newDistance = select(newDistance/DistFNormalization::scaleFactor,
 		                          newDistance/(1. - newDistance),
-		                          newDistance*subVE(distanceTVE->values, 0) < 0));
+		                          newDistance*subVE(distanceTVE->values, 0) < 0,
+		                          type));
 		
 //		kk << assignmentSafe (distanceFieldInternalData->getSubContainer(),  
 //	               		                         select( newDistance, 


### PR DESCRIPTION
The fixed statement needs an extra "type" parameter to avoid the
“call to 'select' is ambiguous” error.
This issue affects all level set examples.

This solves issue #36 
