### PR TITLE
issue #31 – LLVM does not allow Implicit conversions between built-in vector data types

### DIFF
--- a/src/acl/DataTypes/aclConstant.h
+++ b/src/acl/DataTypes/aclConstant.h
@@ -57,7 +57,11 @@ namespace acl
 
 	template <typename T> std::string Constant<T>::str(const KernelConfiguration & kernelConfig) const
 	{
-		return valueStr;
+   #ifdef __llvm__
+		return (typeid(T) == typeid(float) || typeid(T) == typeid(double)) ? "(float)"+valueStr : valueStr;
+   #else
+      return valueStr;
+   #endif
 	}
 
 


### PR DESCRIPTION
Implicit conversions between built-in vector data types (here double to float) are disallowed in OpenCL 1.2, and LLVM does enforce this. Therefore explicitly coerce ACL constants to float.